### PR TITLE
ensure NeoPixel color correct when going to user program

### DIFF
--- a/inc/neopixel.h
+++ b/inc/neopixel.h
@@ -77,6 +77,9 @@ static inline void neopixel_send_buffer(const uint8_t *ptr, int numBytes) {
     volatile uint32_t *clraddr = &PORT->Group[portNum].OUTCLR.reg;
 
     neopixel_send_buffer_core(clraddr, pinMask, ptr, numBytes);
+    // Without this delay, NeoPixel may show as very bright green or other random color when user program starts.
+    delay(1);
+    
 }
 
 #endif


### PR DESCRIPTION
Fixes #7. This was just a guess at a fix, but it works. Now NeoPixel is dark (COLOR_LEAVE) when going to user program. Previous it was very bright green. Problem noticed only on Metro M0 Express. Fixed tested on M0 Express. Also tested on a Feather M0 Express before and after, no issue (but no bright pixel after.)