### PR TITLE
Microsoft update 20180205

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ WFLAGS = \
 CFLAGS = $(COMMON_FLAGS) \
 -x c -c -pipe -nostdlib \
 --param max-inline-insns-single=500 \
--fno-strict-aliasing -fdata-sections -ffunction-sections -mlong-calls \
+-fno-strict-aliasing -fdata-sections -ffunction-sections \
 -D__$(CHIP_VARIANT)__ \
 $(WFLAGS)
 
@@ -43,7 +43,7 @@ endif
 LDFLAGS= $(COMMON_FLAGS) \
 -Wall -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--unresolved-symbols=report-all -Wl,--warn-common \
 -Wl,--warn-section-align -Wl,--warn-unresolved-symbols \
--save-temps  \
+-save-temps -nostartfiles \
 --specs=nano.specs --specs=nosys.specs
 BUILD_PATH=build/$(BOARD)
 INCLUDES = -I. -I./inc -I./inc/preprocessor

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,6 @@ drop-pkg:
 	rm -rf build/uf2-samd21-$(UF2_VERSION_BASE)
 
 all-boards:
-	for f in `cd boards; ls` ; do $(MAKE) BOARD=$$f drop-board ; done
+	for f in `cd boards; ls` ; do "$(MAKE)" BOARD=$$f drop-board ; done
 
 drop: all-boards drop-pkg

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,13 @@ $(WFLAGS)
 UF2_VERSION_BASE = $(shell git describe --dirty --always --tags)
 
 ifeq ($(CHIP_FAMILY), samd21)
-LINKER_SCRIPT=./lib/samd21/samd21a/gcc/gcc/samd21j18a_flash.ld
+LINKER_SCRIPT=scripts/samd21j18a.ld
 BOOTLOADER_SIZE=8192
 SELF_LINKER_SCRIPT=scripts/samd21j18a_self.ld
 endif
 
 ifeq ($(CHIP_FAMILY), samd51)
-LINKER_SCRIPT=./lib/samd51/gcc/gcc/samd51j18a_flash.ld
+LINKER_SCRIPT=scripts/samd51j19a.ld
 BOOTLOADER_SIZE=16384
 SELF_LINKER_SCRIPT=scripts/samd51j19a_self.ld
 endif

--- a/boards/metro_m0/board_config.h
+++ b/boards/metro_m0/board_config.h
@@ -1,8 +1,6 @@
 #ifndef BOARD_CONFIG_H
 #define BOARD_CONFIG_H
 
-#define __SAMD21G18A__ 1
-
 #define VENDOR_NAME "Adafruit Industries"
 #define PRODUCT_NAME "Metro M0"
 #define VOLUME_LABEL "METROBOOT"

--- a/inc/neopixel.h
+++ b/inc/neopixel.h
@@ -12,7 +12,6 @@ static void neopixel_send_buffer_core(volatile uint32_t *clraddr, uint32_t pinMa
                                       const uint8_t *ptr, int numBytes) {
     asm volatile("        push    {r4, r5, r6, lr};"
                  "        add     r3, r2, r3;"
-                 "        cpsid   i;"
                  "loopLoad:"
                  "        ldrb r5, [r2, #0];" // r5 := *ptr
                  "        add  r2, #1;"       // ptr++
@@ -56,7 +55,6 @@ static void neopixel_send_buffer_core(volatile uint32_t *clraddr, uint32_t pinMa
                  "        bcs stop;"
                  "        b loopLoad;"
                  "stop:"
-                 "        cpsie i;"
                  "        pop {r4, r5, r6, pc};"
                  "");
 }
@@ -69,14 +67,22 @@ static inline void neopixel_send_buffer(const uint8_t *ptr, int numBytes) {
     PINOP(BOARD_NEOPIXEL_PIN, DIRSET);
 
     // turn off mux too, needed for metro m0 but no harm done!
-    PORT->Group[BOARD_NEOPIXEL_PIN / 32].PINCFG[BOARD_NEOPIXEL_PIN % 32].reg=(uint8_t)(PORT_PINCFG_INEN) ;
+    PORT->Group[BOARD_NEOPIXEL_PIN / 32].PINCFG[BOARD_NEOPIXEL_PIN % 32].reg =
+        (uint8_t)(PORT_PINCFG_INEN);
 
     PINOP(BOARD_NEOPIXEL_PIN, OUTCLR);
     delay(1);
 
     volatile uint32_t *clraddr = &PORT->Group[portNum].OUTCLR.reg;
 
-    neopixel_send_buffer_core(clraddr, pinMask, ptr, numBytes);
+    // equivalent to cpu_irq_is_enabled()
+    if (__get_PRIMASK() == 0) {
+        __disable_irq();
+        neopixel_send_buffer_core(clraddr, pinMask, ptr, numBytes);
+        __enable_irq();
+    } else {
+        neopixel_send_buffer_core(clraddr, pinMask, ptr, numBytes);
+    }
 }
 
 #endif

--- a/inc/uf2.h
+++ b/inc/uf2.h
@@ -31,6 +31,10 @@
 #define INDEX_URL "https://www.pxt.io/"
 #endif
 
+#ifndef WEBUSB_URL
+#define WEBUSB_URL "pxt.io"
+#endif
+
 #include "uf2_version.h"
 
 // needs to be more than ~4200 (to force FAT16)
@@ -51,7 +55,9 @@
 // Support Human Interface Device (HID) - serial, flashing and debug
 #define USE_HID 1 // 788 bytes
 // Expose HID via WebUSB
-#define USE_WEBUSB 0 // 400 bytes
+#define USE_WEBUSB 0
+// Return allowed WebUSB URLs; it seems to have been removed from the standard
+#define USE_WEBUSB_ORIGINS 0
 // Doesn't yet disable code, just enumeration
 #define USE_MSC 1
 
@@ -112,9 +118,15 @@
 #define WEB_VERSION ""
 #endif
 
+#if USE_MSC_HANDOVER
+#define MSC_HANDOVER_VERSION "O"
+#else
+#define MSC_HANDOVER_VERSION ""
+#endif
+
 #define UF2_VERSION                                                                                \
     UF2_VERSION_BASE " " CDC_VERSION LOGS_VERSION FAT_VERSION ASSERT_VERSION HID_VERSION           \
-        WEB_VERSION RESET_VERSION
+        WEB_VERSION RESET_VERSION MSC_HANDOVER_VERSION
 
 // End of config
 

--- a/inc/uf2.h
+++ b/inc/uf2.h
@@ -31,10 +31,6 @@
 #define INDEX_URL "https://www.pxt.io/"
 #endif
 
-#ifndef WEBUSB_URL
-#define WEBUSB_URL "pxt.io"
-#endif
-
 #include "uf2_version.h"
 
 // needs to be more than ~4200 (to force FAT16)
@@ -55,9 +51,7 @@
 // Support Human Interface Device (HID) - serial, flashing and debug
 #define USE_HID 1 // 788 bytes
 // Expose HID via WebUSB
-#define USE_WEBUSB 0
-// Return allowed WebUSB URLs; it seems to have been removed from the standard
-#define USE_WEBUSB_ORIGINS 0
+#define USE_WEBUSB 1
 // Doesn't yet disable code, just enumeration
 #define USE_MSC 1
 

--- a/inc/uf2format.h
+++ b/inc/uf2format.h
@@ -90,6 +90,8 @@ static inline void hf2_handover(uint8_t ep) {
     }
 }
 
+// the ep_in/ep_out are without the 0x80 mask
+// cbw_tag is in the same bit format as it came
 static inline void check_uf2_handover(uint8_t *buffer, uint32_t blocks_remaining, uint8_t ep_in,
                                       uint8_t ep_out, uint32_t cbw_tag) {
     if (!is_uf2_block(buffer))

--- a/scripts/dbgtool.js
+++ b/scripts/dbgtool.js
@@ -63,7 +63,7 @@ function main() {
 
     if (!pkgDir) fatal("cannot find Arduino packages directory")
 
-    let openocdPath = pkgDir + "tools/openocd/0.9.0-arduino/"
+    let openocdPath = pkgDir + "tools/openocd/0.10.0-arduino1-static/"
     if (!fs.existsSync(openocdPath)) fatal("openocd not installed in Arduino")
 
     let openocdBin = openocdPath + "bin/openocd"
@@ -71,7 +71,7 @@ function main() {
     if (process.platform == "win32")
         openocdBin += ".exe"
 
-    let zeroCfg = pkgDir + "hardware/samd/1.6.8/variants/arduino_zero/openocd_scripts/arduino_zero.cfg"
+    let zeroCfg = pkgDir + "hardware/samd/1.6.17/variants/arduino_zero/openocd_scripts/arduino_zero.cfg"
 
     let cmd = `telnet_port disabled; init; halt; `
     if (mode == "map")

--- a/scripts/gendata.js
+++ b/scripts/gendata.js
@@ -32,7 +32,9 @@ infostr = infostr.split(/\r?\n/).map(l => "// " + l + "\n").join("")
 
 let size = buf.length
 let s = infostr + "\n"
-s += "const uint8_t bootloader[" + size + "] __attribute__ ((aligned (4))) = {"
+s += "const uint8_t bootloader[" + size + "] "
+s += "__attribute__ ((section(\".vectors.needs.to.go.first\"))) "
+s += "__attribute__ ((aligned (4))) = {"
 function tohex(v) {
   return "0x" + ("00" + v.toString(16)).slice(-2) + ", "
 }

--- a/scripts/samd21j18a.ld
+++ b/scripts/samd21j18a.ld
@@ -1,27 +1,41 @@
 /**
  * \file
  *
- * \brief Linker script for running in internal FLASH on the SAMD51J19A
+ * \brief Linker script for running in internal FLASH on the SAMD21J18A
  *
- * Copyright (c) 2017 Microchip Technology Inc.
+ * Copyright (c) 2014-2015 Atmel Corporation. All rights reserved.
  *
  * \asf_license_start
  *
  * \page License
  *
- * SPDX-License-Identifier: Apache-2.0
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the Licence at
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an AS IS BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  *
  * \asf_license_stop
  *
@@ -35,14 +49,12 @@ SEARCH_DIR(.)
 /* Memory Spaces Definitions */
 MEMORY
 {
-  rom      (rx)  : ORIGIN = 0x00004000, LENGTH = 0x00080000 - 0x4000
-  ram      (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00030000
-  bkupram  (rwx) : ORIGIN = 0x47000000, LENGTH = 0x00002000
-  qspi     (rwx) : ORIGIN = 0x04000000, LENGTH = 0x01000000
+  rom      (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00002000
+  ram      (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00008000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : DEFINED(__stack_size__) ? __stack_size__ : 0xC000;
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : DEFINED(__stack_size__) ? __stack_size__ : 0x2000;
 
 /* Section Definitions */
 SECTIONS
@@ -78,6 +90,8 @@ SECTIONS
         KEEP (*(SORT(.ctors.*)))
         KEEP (*crtend.o(.ctors))
 
+        /*
+
         . = ALIGN(4);
         KEEP(*(.fini))
 
@@ -91,6 +105,7 @@ SECTIONS
         KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
         KEEP (*(SORT(.dtors.*)))
         KEEP (*crtend.o(.dtors))
+        */
 
         . = ALIGN(4);
         _efixed = .;            /* End of text section */
@@ -117,24 +132,6 @@ SECTIONS
         _erelocate = .;
     } > ram
 
-    .bkupram (NOLOAD):
-    {
-        . = ALIGN(8);
-        _sbkupram = .;
-        *(.bkupram .bkupram.*);
-        . = ALIGN(8);
-        _ebkupram = .;
-    } > bkupram
-
-    .qspi (NOLOAD):
-    {
-        . = ALIGN(8);
-        _sqspi = .;
-        *(.qspi .qspi.*);
-        . = ALIGN(8);
-        _eqspi = .;
-    } > qspi
-
     /* .bss section which is used for uninitialized data */
     .bss (NOLOAD) :
     {
@@ -160,4 +157,9 @@ SECTIONS
 
     . = ALIGN(4);
     _end = . ;
+
+    _binfo_start = 0x00002000 - 4 * 4;
+    .binfo _binfo_start : {
+      KEEP(*(.binfo)) ;
+    } > rom
 }

--- a/scripts/samd51j19a.ld
+++ b/scripts/samd51j19a.ld
@@ -14,9 +14,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the Licence at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an AS IS BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,10 +35,8 @@ SEARCH_DIR(.)
 /* Memory Spaces Definitions */
 MEMORY
 {
-  rom      (rx)  : ORIGIN = 0x00004000, LENGTH = 0x00080000 - 0x4000
+  rom      (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00080000
   ram      (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00030000
-  bkupram  (rwx) : ORIGIN = 0x47000000, LENGTH = 0x00002000
-  qspi     (rwx) : ORIGIN = 0x04000000, LENGTH = 0x01000000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */
@@ -78,6 +76,8 @@ SECTIONS
         KEEP (*(SORT(.ctors.*)))
         KEEP (*crtend.o(.ctors))
 
+        /*
+
         . = ALIGN(4);
         KEEP(*(.fini))
 
@@ -91,6 +91,7 @@ SECTIONS
         KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
         KEEP (*(SORT(.dtors.*)))
         KEEP (*crtend.o(.dtors))
+        */
 
         . = ALIGN(4);
         _efixed = .;            /* End of text section */
@@ -117,24 +118,6 @@ SECTIONS
         _erelocate = .;
     } > ram
 
-    .bkupram (NOLOAD):
-    {
-        . = ALIGN(8);
-        _sbkupram = .;
-        *(.bkupram .bkupram.*);
-        . = ALIGN(8);
-        _ebkupram = .;
-    } > bkupram
-
-    .qspi (NOLOAD):
-    {
-        . = ALIGN(8);
-        _sqspi = .;
-        *(.qspi .qspi.*);
-        . = ALIGN(8);
-        _eqspi = .;
-    } > qspi
-
     /* .bss section which is used for uninitialized data */
     .bss (NOLOAD) :
     {
@@ -160,4 +143,9 @@ SECTIONS
 
     . = ALIGN(4);
     _end = . ;
+
+    _binfo_start = 0x00002000 - 4 * 4;
+    .binfo _binfo_start : {
+      KEEP(*(.binfo)) ;
+    } > rom
 }

--- a/src/fat.c
+++ b/src/fat.c
@@ -231,11 +231,13 @@ void write_block(uint32_t block_no, uint8_t *data, bool quiet, WriteState *state
             if (state->numWritten >= state->numBlocks) {
                 // wait a little bit before resetting, to avoid Windows transmit error
                 // https://github.com/Microsoft/uf2-samd21/issues/11
-                resetHorizon = timerHigh + 30;
+                if (!quiet)
+                    resetHorizon = timerHigh + 30;
                 // resetIntoApp();
             }
         }
     } else {
-        resetHorizon = timerHigh + 300;
+        if (!quiet)
+            resetHorizon = timerHigh + 300;
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -162,6 +162,9 @@ int main(void) {
         while (1) {
         }
 
+#if USB_PID == 0x0013  // Metro m0
+    delay(100);
+#endif
     led_init();
 
     logmsg("Start");

--- a/src/msc.c
+++ b/src/msc.c
@@ -846,21 +846,11 @@ void handoverPrep() {
 }
 
 static void handover(UF2_HandoverArgs *args) {
-    // reset interrupt vectors, so that we're not disturbed by
-    // interrupt handlers from user space
-
-    // for (int i = 1; i <= 0x1f; ++i){
-    //    system_interrupt_disable(i);
-    //}
-
     handoverPrep();
 
     PacketBuffer cache = {0};
     WriteState writeState = {0};
-
-    // for (int i = 0; i < 1000000; i++) {
-    //    asm("nop");
-    //}
+    cache.read_job = 2;
 
     // They may have 0x80 bit set
     args->ep_in &= 0xf;

--- a/src/sam_ba_monitor.c
+++ b/src/sam_ba_monitor.c
@@ -219,7 +219,7 @@ void sam_ba_monitor_run(void) {
                         // Erase the flash memory starting from ADDR to the end
                         // of flash.
 
-                        flash_erase_to_end(current_number);
+                        flash_erase_to_end((uint32_t *) current_number);
 
                         // Notify command completed
                         cdc_write_buf("X\n\r", 3);


### PR DESCRIPTION
Same pull request also sent to Microsoft (https://github.com/Microsoft/uf2-samd21/pull/31). This brings us up to date with v1.26.0 of Microsoft/uf2-samd21. Major changes there have been compilation improvements to save space and addition of WebUSB.

I tested this casually on a CPX and one other board (I forget which). I didn't test WebUSB specifically. This includes the latest upstream fixes that remove the WebUSB notification when you plug in the board.